### PR TITLE
Unpin moment dependency to fix security vulnerability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+    - "stable"
     - "0.10"
 
 before_script:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">= 0.10.0"
   },
   "dependencies": {
-    "moment": "~2.10.2",
+    "moment": "^2.16.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Details of the vulnerability are described here:

 * https://snyk.io/vuln/npm:moment:20161019
 * https://www.versioneye.com/Node.JS/moment/2.10.6

This also:

 * adds stable node to unit testing matrix

Would like to get a release cut for this, and to have `blue-button` updated as well :pray: 

----

Filed upstream issue https://github.com/amida-tech/blue-button/issues/253 as well